### PR TITLE
[Refactoring] Update to latest TornadoVM API (From TaskSchedules to TaskGraphs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ export PATH="${PATH}:${TORNADO_QSIM_ROOT=}/bin"
 export TORNADO_ROOT=<path to TornadoVM>
 export PATH="${PATH}:${TORNADO_ROOT}/bin/bin/"
 export TORNADO_SDK=${TORNADO_ROOT}/bin/sdk
-export JAVA_HOME=${TORNADO_ROOT}/TornadoVM-GraalJDK11/graalvm-ce-java11-22.2.0
+export JAVA_HOME=${TORNADO_ROOT}/TornadoVM-GraalJDK11/graalvm-ce-java11-22.3.2
 ```
 
 Load the environment:

--- a/TornadoQSim/pom.xml
+++ b/TornadoQSim/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>tornado</groupId>
             <artifactId>tornado-api</artifactId>
-            <version>0.15-dev</version>
+            <version>0.15.2-dev</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/TornadoQSim/src/main/java/uk/ac/manchester/tornado/qsim/simulator/unitary/UnitaryDataProvider.java
+++ b/TornadoQSim/src/main/java/uk/ac/manchester/tornado/qsim/simulator/unitary/UnitaryDataProvider.java
@@ -4,7 +4,7 @@
  *
  * URL: https://github.com/beehive-lab/TornadoQSim
  *
- * Copyright (c) 2021-2022, APT Group, Department of Computer Science,
+ * Copyright (c) 2021-2023, APT Group, Department of Computer Science,
  * The University of Manchester. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -21,7 +21,8 @@
  */
 package uk.ac.manchester.tornado.qsim.simulator.unitary;
 
-import uk.ac.manchester.tornado.api.TaskSchedule;
+import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.qsim.circuit.Step;
 import uk.ac.manchester.tornado.qsim.circuit.operation.*;
 import uk.ac.manchester.tornado.qsim.circuit.operation.enums.GateType;
@@ -134,7 +135,11 @@ class UnitaryDataProvider {
 
     private void buildControlGate(float[] gR, float[] gI, int c, int t, float[] rR, float[] rI, int rSize) {
         if (accelerated) {
-            new TaskSchedule("sControlGate").task("tBuildControlGate", UnitaryOperand::buildControlGate, gR, gI, c, t, rR, rI, rSize).streamOut(rR, rI).execute();
+            new TaskGraph("sControlGate")
+                    .transferToHost(DataTransferMode.FIRST_EXECUTION, gR, gI)
+                    .task("tBuildControlGate", UnitaryOperand::buildControlGate, gR, gI, c, t, rR, rI, rSize)
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, rR, rI)
+                    .execute();
         } else {
             UnitaryOperand.buildControlGate(gR, gI, c, t, rR, rI, rSize);
         }

--- a/TornadoQSim/src/main/java/uk/ac/manchester/tornado/qsim/simulator/unitary/UnitaryDataProvider.java
+++ b/TornadoQSim/src/main/java/uk/ac/manchester/tornado/qsim/simulator/unitary/UnitaryDataProvider.java
@@ -22,6 +22,7 @@
 package uk.ac.manchester.tornado.qsim.simulator.unitary;
 
 import uk.ac.manchester.tornado.api.TaskGraph;
+import uk.ac.manchester.tornado.api.TornadoExecutionPlan;
 import uk.ac.manchester.tornado.api.enums.DataTransferMode;
 import uk.ac.manchester.tornado.qsim.circuit.Step;
 import uk.ac.manchester.tornado.qsim.circuit.operation.*;
@@ -135,11 +136,12 @@ class UnitaryDataProvider {
 
     private void buildControlGate(float[] gR, float[] gI, int c, int t, float[] rR, float[] rI, int rSize) {
         if (accelerated) {
-            new TaskGraph("sControlGate")
+            TaskGraph taskGraph = new TaskGraph("sControlGate")
                     .transferToHost(DataTransferMode.FIRST_EXECUTION, gR, gI)
                     .task("tBuildControlGate", UnitaryOperand::buildControlGate, gR, gI, c, t, rR, rI, rSize)
-                    .transferToHost(DataTransferMode.EVERY_EXECUTION, rR, rI)
-                    .execute();
+                    .transferToHost(DataTransferMode.EVERY_EXECUTION, rR, rI);
+            TornadoExecutionPlan executionPlan = new TornadoExecutionPlan(taskGraph.snapshot());
+            executionPlan.execute();
         } else {
             UnitaryOperand.buildControlGate(gR, gI, c, t, rR, rI, rSize);
         }


### PR DESCRIPTION
This PR makes the update to the latest TornadoVM API ([v0.15](https://tornadovm.readthedocs.io/en/latest/CHANGELOG.html#tornadovm-0-15)).

I have also added the update in the pom.xml file to point to the version of the current running main branch, which is `v0.15.2-dev`.

To test the PR:

1. Update to the latest TornadoVM version.
2. Build TornadoQSim:
```bash
$ mvn clean install
```
3. Run the tests, for example `QuantumCode`:
```bash
$ tornado-qsim unitary-accel QuantumCode 3
(--------------------- TornadoVM Quantum Simulator ---------------------)
Running QuantumCode circuit with the Unitary Matrix backend (parallel execution)
State vector:
000  0.00  (0.000 + 0.000i)
001  0.25  (0.000 - 0.500i)
010  0.00  (0.000 + 0.000i)
011  0.25  (0.000 - 0.500i)
100  0.00  (0.000 + 0.000i)
101  0.25  (0.000 - 0.500i)
110  0.00  (0.000 + 0.000i)
111  0.25  (0.000 - 0.500i)
```